### PR TITLE
XML Schema Referenzen auflösbar machen

### DIFF
--- a/Readme.adoc
+++ b/Readme.adoc
@@ -11,7 +11,7 @@ Um den Regelsatz zu verwenden wird in der Anwendung ein zusätzliches Maven-Plug
 <plugin>
     <groupId>com.buschmais.jqassistant</groupId>
     <artifactId>jqassistant-maven-plugin</artifactId>
-    <version>1.6.0</version>
+    <version>1.8.0</version>
     <executions>
         <execution>
             <id>default-cli</id>

--- a/src/main/resources/META-INF/jqassistant-plugin.xml
+++ b/src/main/resources/META-INF/jqassistant-plugin.xml
@@ -1,5 +1,6 @@
-<jqa-plugin:jqassistant-plugin xmlns:jqa-plugin="http://www.buschmais.com/jqassistant/core/plugin/schema/v1.1"
-                               name="IsyFact">
+<jqassistant-plugin xmlns="http://schema.jqassistant.org/plugin/v1.8"
+                    name="IsyFact" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://schema.jqassistant.org/plugin/v1.8 http://schema.jqassistant.org/plugin/jqassistant-plugin-v1.8.xsd">
     <description>Stellt Regeln zur Verwendung der IsyFact bereit.</description>
     <rules>
         <resource>batch.xml</resource>
@@ -18,4 +19,4 @@
         <resource>ueberwachung.xml</resource>
         <resource>isyfact-groups.xml</resource>
     </rules>
-</jqa-plugin:jqassistant-plugin>
+</jqassistant-plugin>

--- a/src/main/resources/META-INF/jqassistant-rules/batch.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/batch.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:batch:Verbindlich">
         <includeConstraint refId="isyfact:batch:AusfuehrungsBeanDarfKeineTransaktionStarten"/>
@@ -55,4 +58,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/core.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/core.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:core:Verbindlich">
         <includeConstraint refId="isyfact:core:BeanNichtPerNameAuslesen"/>
@@ -100,4 +103,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/datetime.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/datetime.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:datetime:Verbindlich">
         <includeConstraint refId="isyfact:datetime:AufrufVonNowOderCurrentTimeMillis"/>
@@ -30,4 +33,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/fehlerbehandlung.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/fehlerbehandlung.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:fehlerbehandlung:Empfohlen">
         <includeConstraint refId="isyfact:fehlerbehandlung:ExceptionsErbenVonPlisException"/>
@@ -38,4 +41,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/gui.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/gui.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:gui:Empfohlen">
         <includeConstraint refId="isyfact:gui:ModelBeanSerializable"/>
@@ -130,4 +133,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/isyfact-groups.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/isyfact-groups.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:Verbindlich">
         <includeGroup refId="isyfact:batch:Verbindlich"/>
@@ -22,4 +25,4 @@
         <includeGroup refId="isyfact:ueberwachung:Empfohlen"/>
     </group>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/konfiguration.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/konfiguration.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:konfiguration:Verbindlich">
         <includeConstraint refId="isyfact:konfiguration:BenutzeKeineInternenKlassen"/>
@@ -55,4 +58,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/layer.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/layer.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:layer:Verbindlich">
         <includeConstraint refId="isyfact:layer:ZugriffAufCoreLayerUeberInterface"/>
@@ -259,4 +262,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/logging.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/logging.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:logging:Verbindlich">
         <includeConstraint refId="isyfact:logging:IsyLoggerMussVerwendetWerden"/>
@@ -105,4 +108,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/maven.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/maven.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <concept id="isyfact:maven:MainArtifact">
         <description>
@@ -20,4 +23,4 @@
         ]]></cypher>
     </concept>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/package.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/package.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:package:Verbindlich">
         <includeConstraint refId="isyfact:package:AlleJavaKlassenMuessenImWurzelPackageLiegen"/>
@@ -81,4 +84,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/persistenz.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/persistenz.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:persistence:Empfohlen">
         <includeConstraint refId="isyfact:persistence:EntitiesLiegenInPackageEntity"/>
@@ -211,4 +214,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/service.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/service.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:service:Verbindlich">
         <includeConstraint refId="isyfact:service:ExceptionAnServiceSchnitstelle"/>
@@ -96,4 +99,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/spring.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/spring.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <concept id="isyfact:spring:SpringXmlKonfiguration">
         <description>
@@ -16,4 +19,4 @@
         ]]></cypher>
     </concept>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/ueberwachung.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/ueberwachung.xml
@@ -1,4 +1,7 @@
-<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.1">
+<jqassistant-rules
+        xmlns="http://schema.jqassistant.org/rule/v1.8"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://schema.jqassistant.org/rule/v1.8 https://schema.jqassistant.org/rule/jqassistant-rule-v1.8.xsd">
 
     <group id="isyfact:ueberwachung:Empfohlen">
         <includeConstraint refId="isyfact:ueberwachung:MBeanSuffix"/>
@@ -78,4 +81,4 @@
         ]]></cypher>
     </constraint>
 
-</jqa:jqassistant-rules>
+</jqassistant-rules>


### PR DESCRIPTION
Im aktuellen master werden die XML Schema Referenzen in den Regeldefinitionen nicht aufgelöst.

Mit der Umstellung auf die seit Version 1.8 von jQAssistant existierenden Schema Referenzen wird dies behoben.
